### PR TITLE
fix crash in arm

### DIFF
--- a/include/ilog2.h
+++ b/include/ilog2.h
@@ -48,7 +48,7 @@ static inline uint64_t ilog2_64(uint64_t x) {
 #else
     if (!x)
         return 0;
-    return __builtin_clz(x) ^ 63;
+    return __builtin_clzll(x) ^ 63;
 #endif
 }
 


### PR DESCRIPTION
otherwise it will crash as soon as it tries to call mremap with a size of 0 (as it is done usually during initialization of the mime_types hashmap)